### PR TITLE
add methods for managing glossaries

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,5 +1,7 @@
 package deepl
 
+import "time"
+
 type translateResponse struct {
 	Translations []Translation `json:"translations"`
 }
@@ -8,4 +10,23 @@ type translateResponse struct {
 type Translation struct {
 	DetectedSourceLanguage string `json:"detected_source_language"`
 	Text                   string `json:"text"`
+}
+
+// Glossary as per
+// https://www.deepl.com/docs-api/managing-glossaries/creating-a-glossary/
+type Glossary struct {
+	GlossaryID   string    `json:"glossary_id"`
+	Name         string    `json:"name"`
+	Ready        bool      `json:"ready"`
+	SourceLang   string    `json:"source_lang"`
+	TargetLang   string    `json:"target_lang"`
+	CreationTime time.Time `json:"creation_time"`
+	EntryCount   int       `json:"entry_count"`
+}
+
+// A GlossaryEntry represents a single source→target entry in a glossary. This
+// is serialized to/from tab-separated values for DeepL.
+type GlossaryEntry struct {
+	Source string
+	Target string
 }

--- a/deepl.go
+++ b/deepl.go
@@ -191,7 +191,6 @@ func (c *Client) Translate(ctx context.Context, text string, targetLang Language
 //	}
 func (c *Client) TranslateMany(ctx context.Context, texts []string, targetLang Language, opts ...TranslateOption) ([]Translation, error) {
 	vals := make(url.Values)
-	vals.Set("auth_key", c.authKey)
 	vals.Set("target_lang", string(targetLang))
 
 	for _, text := range texts {
@@ -206,6 +205,8 @@ func (c *Client) TranslateMany(ctx context.Context, texts []string, targetLang L
 	if err != nil {
 		return nil, fmt.Errorf("build request: %w", err)
 	}
+
+	req.Header.Add("Authorization", "DeepL-Auth-Key "+c.authKey)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := c.client.Do(req)

--- a/deepl.go
+++ b/deepl.go
@@ -36,7 +36,7 @@ type TranslateOption func(url.Values)
 
 // Error is a DeepL error.
 type Error struct {
-	// The HTTP error code, returned by the deepl API.
+	// The HTTP error code, returned by the DeepL API.
 	Code int
 
 	Body []byte
@@ -228,7 +228,10 @@ func (c *Client) TranslateMany(ctx context.Context, texts []string, targetLang L
 }
 
 func errorFromResp(r *http.Response) error {
-	b, _ := ioutil.ReadAll(r.Body)
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
 	return Error{
 		Code: r.StatusCode,
 		Body: b,
@@ -400,10 +403,9 @@ func (err Error) Error() string {
 			return fmt.Sprintf("unexpected HTTP status %s (%s)",
 				http.StatusText(err.Code),
 				strings.TrimSpace(string(err.Body)))
-		} else {
-			return fmt.Sprintf("unexpected HTTP status %s",
-				http.StatusText(err.Code))
 		}
+		return fmt.Sprintf("unexpected HTTP status %s",
+			http.StatusText(err.Code))
 	}
 }
 

--- a/deepl_test.go
+++ b/deepl_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Client.TranslateMany", func() {
 func itAddsTheRequiredFields(request *chan *http.Request, targetLang *deepl.Language) {
 	It("adds the auth key", func(done Done) {
 		req := <-*request
-		Ω(req.FormValue("auth_key")).Should(Equal("an-auth-key"))
+		Ω(req.Header.Get("Authorization")).Should(Equal("DeepL-Auth-Key an-auth-key"))
 		close(done)
 	})
 


### PR DESCRIPTION
See https://www.deepl.com/docs-api/managing-glossaries/

The glossary API requires authentication via the Authorization header (as
opposed to a parameter).

Also capture the body (contains error details) when the HTTP status code does
not match our expectation. This is useful for recognizing when specifying an
unsupported language combination, for example.

fixes https://github.com/bounoable/deepl/issues/3