### PR TITLE
Options: new option ShowBilledChars

### DIFF
--- a/api.go
+++ b/api.go
@@ -10,6 +10,8 @@ type translateResponse struct {
 type Translation struct {
 	DetectedSourceLanguage string `json:"detected_source_language"`
 	Text                   string `json:"text"`
+	// BilledCharacters has the value only if ShowBilledChars(true) option was set.
+	BilledCharacters       *int   `json:"billed_characters"`
 }
 
 // Glossary as per

--- a/deepl.go
+++ b/deepl.go
@@ -68,6 +68,14 @@ func SourceLang(lang Language) TranslateOption {
 	}
 }
 
+// ShowBilledChars returns a TranslateOption that asks DeepL to return the
+// number of billed characters.
+func ShowBilledChars(show bool) TranslateOption {
+	return func(vals url.Values) {
+		vals.Set("show_billed_characters", boolString(show))
+	}
+}
+
 // SplitSentences returns a TranslateOption that sets the `split_sentences`
 // DeepL option.
 func SplitSentences(split SplitSentence) TranslateOption {

--- a/options_test.go
+++ b/options_test.go
@@ -16,6 +16,17 @@ func TestSourceLang(t *testing.T) {
 	assert.Equal(t, string(deepl.German), vals.Get("source_lang"))
 }
 
+func TestShowBilledChars(t *testing.T) {
+	vals := make(url.Values)
+	assert.Equal(t, "", vals.Get("show_billed_characters"))
+	deepl.ShowBilledChars(true)(vals)
+	assert.Equal(t, "1", vals.Get("show_billed_characters"))
+	deepl.ShowBilledChars(false)(vals)
+	assert.Equal(t, "0", vals.Get("show_billed_characters"))
+	deepl.ShowBilledChars(true)(vals)
+	assert.Equal(t, "1", vals.Get("show_billed_characters"))
+}
+
 func TestSplitSentences(t *testing.T) {
 	splits := []deepl.SplitSentence{
 		deepl.SplitNone,


### PR DESCRIPTION
This will let the users see how many characters they've used when using the TranslateMany function.

I would add the same field to Translate as well, but the API is not very extensible there.